### PR TITLE
Fixes government feed

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -42,7 +42,7 @@ get '/feed' do
   http.use_ssl = true
   req = Net::HTTP::Get.new('/government/feed')
   response = http.request(req)
-  Hash.from_xml(response.body).to_json
+  JSON.generate Hash.from_xml(response.body)
 end
 
 def get_token

--- a/server.rb
+++ b/server.rb
@@ -40,7 +40,7 @@ end
 get '/feed' do
   http = Net::HTTP.new('www.gov.uk', 443)
   http.use_ssl = true
-  req = Net::HTTP::Get.new('/government/feed.atom')
+  req = Net::HTTP::Get.new('/government/feed')
   response = http.request(req)
   Hash.from_xml(response.body).to_json
 end


### PR DESCRIPTION
Previous URL:
https://www.gov.uk/government/feed.atom

New URL:
https://www.gov.uk/government/feed

---

Replaces `.to_json` method with `JSON.generate`
This was changed because to_json throws an active support error:
 `uninitialized constant ActiveSupport::JSON`