### PR TITLE
Replace Google Analytics ID with main profile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
 
   matrix.settings = {
     authServer: '/token',
-    profileId: '67465768'
+    profileId: '53872948'
   };
 
   $(function(){

--- a/public/search.html
+++ b/public/search.html
@@ -23,7 +23,7 @@
 
   matrix.settings = {
     authServer: '/token',
-    profileId: '67465768'
+    profileId: '53872948'
   };
 
   $(function(){


### PR DESCRIPTION
Live searches weren't working on the display screen, so this PR replaces the Google Analytics profile ID with a different one.

*CAUTION!* Product manager testing in live by raising PRs (but it's an internal screen so should be fine).