### PR TITLE
Update site search page path

### DIFF
--- a/public/javascripts/search.js
+++ b/public/javascripts/search.js
@@ -15,7 +15,7 @@
         + "ids=ga:"+ profileId +"&"
         + "metrics=ga:activeVisitors&"
         + "dimensions=ga:pageTitle,ga:pagePath&"
-        + "filters="+ encodeURIComponent("ga:pagePath==/search") +"&"
+        + "filters="+ encodeURIComponent("ga:pagePath==/search/all") +"&"
         + "sort=-ga:activeVisitors&"
         + "max-results=10000";
     },


### PR DESCRIPTION
After releasing the new faceted site search, the URL has changed from https://www.gov.uk/search to https://www.gov.uk/search/all.