### PR TITLE
Remove queries containing `<script>`

### DIFF
--- a/public/javascripts/search.js
+++ b/public/javascripts/search.js
@@ -24,6 +24,10 @@
       if(term.indexOf('@') > -1){
         return false;
       }
+       // Nothing that looks like a Smokey test
+      if(term.indexOf('<script>') > -1){
+        return false;
+      }
       // Nothing that is just a number
       if(term.match(/^[0-9\s]+$/)){
         return false;


### PR DESCRIPTION
We run [Smokey tests](https://github.com/alphagov/smokey/blob/ce9cf97ff959201eaf700e38a69c74d2290da215/features/finder_frontend.feature#L59) that search for potential XSS issues, found by searching for queries like `<script>alert(123)</script>`. We don't need to see these on the display screen.