### PR TITLE
Add a few more popular terms

### DIFF
--- a/public/javascripts/search.js
+++ b/public/javascripts/search.js
@@ -157,7 +157,7 @@
       search.updateElement = search.updateCoronaElement;
     },
     coronaTerm: function(term){
-      if(term.toLowerCase().match(/corona|wash|hands|covid|COVID-19|COVID19|virus|ssp\ |sick|self.isolation|isolation|closures?|quarantine/)){
+      if(term.toLowerCase().match(/corona|wash|hands|covid|COVID-19|COVID19|virus|ssp\ |sick|self.isolation|isolation|closures?|quarantine|key.workers?|essential|vulnerable|shops?|lockdown/)){
         return true;
       }
       return false;


### PR DESCRIPTION
The question-type searches have been added to the GOV.UK coronavirus dashboard, so it seems sensible to pick up on some of those key words here too.