### PR TITLE
Remove mention of Aviation House

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Screen to display live data from GOV.UK. Includes number of people on GOV.UK,
 latest searches, trending and recent content. Not publicly accessible because
 there's sometimes personal data in the latest searches.
 
-It runs on a TV on the 6th floor of Aviation House.
-
 ![screenshot](docs/screenshot.png)
 
 http://govuk-display-screen.herokuapp.com/


### PR DESCRIPTION
We're not in Aviation House any more.