### PR TITLE
Fix `activesupport` require error

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -4,8 +4,8 @@ require 'json'
 require 'rack-cache'
 require 'net/http'
 require 'net/https'
+require 'active_support'
 require 'active_support/core_ext/hash'
-require 'active_support/core_ext/object'
 
 use Rack::Cache
 set :public_folder, 'public'


### PR DESCRIPTION
The right hand column showing the `/feed` route is not currently working. On the Heroku JavaScript console it shows..

`Failed to load resource: the server responded with a status of 500 (Internal Server Error)`

In the log it shows...

`NameError - uninitialized constant ActiveSupport::XMLConverter::XmlMini`

The issue is related to a change made in `activesupport` so that now we need to `require 'active_support'` before `require 'active_support/core_ext/hash`.

| Before | After |
|---|---|
|<img width="1792" alt="Screenshot 2022-09-21 at 16 27 25" src="https://user-images.githubusercontent.com/44037625/191546451-dc92eb99-b63a-400b-ab21-79e873c08f0a.png">|<img width="1792" alt="Screenshot 2022-09-21 at 16 27 39" src="https://user-images.githubusercontent.com/44037625/191546536-807e80c7-ce2b-42a0-9078-205600961081.png">|
