### PR TITLE
Use GA4 API for Analytics data 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,5 @@ gem 'rack-cache'
 gem 'sass'
 gem 'sinatra'
 gem "dotenv"
-gem "google-api-client"
-gem "googleauth"
 gem "google-analytics-data-v1beta"
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ gem 'sinatra'
 gem "dotenv"
 gem "google-api-client"
 gem "googleauth"
+gem "google-analytics-data-v1beta"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     concurrent-ruby (1.1.10)
-    declarative (0.0.20)
     dotenv (2.8.1)
     faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
@@ -26,30 +25,9 @@ GEM
       googleapis-common-protos-types (>= 1.3.1, < 2.a)
       googleauth (~> 1.0)
       grpc (~> 1.36)
-    gems (1.2.0)
     google-analytics-data-v1beta (0.6.0)
       gapic-common (>= 0.12, < 2.a)
       google-cloud-errors (~> 1.0)
-    google-api-client (0.53.0)
-      google-apis-core (~> 0.1)
-      google-apis-generator (~> 0.1)
-    google-apis-core (0.9.1)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (>= 0.16.2, < 2.a)
-      httpclient (>= 2.8.1, < 3.a)
-      mini_mime (~> 1.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.a)
-      rexml
-      webrick
-    google-apis-discovery_v1 (0.12.0)
-      google-apis-core (>= 0.9.0, < 2.a)
-    google-apis-generator (0.11.0)
-      activesupport (>= 5.0)
-      gems (~> 1.2)
-      google-apis-core (>= 0.9.1, < 2.a)
-      google-apis-discovery_v1 (~> 0.5)
-      thor (>= 0.20, < 2.a)
     google-cloud-errors (1.3.0)
     google-protobuf (3.21.9)
     googleapis-common-protos (1.3.12)
@@ -68,13 +46,11 @@ GEM
     grpc (1.50.0)
       google-protobuf (~> 3.21)
       googleapis-common-protos-types (~> 1.0)
-    httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
     jwt (2.5.0)
     memoist (0.16.2)
-    mini_mime (1.1.2)
     minitest (5.16.3)
     multi_json (1.15.0)
     mustermann (3.0.0)
@@ -89,12 +65,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.1.2)
-    rexml (3.2.5)
     ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -111,13 +81,9 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.2)
       tilt (~> 2.0)
-    thor (1.2.1)
     tilt (2.0.11)
-    trailblazer-option (0.1.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    uber (0.1.0)
-    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -126,8 +92,6 @@ DEPENDENCIES
   activesupport
   dotenv
   google-analytics-data-v1beta
-  google-api-client
-  googleauth
   json
   rack-cache
   sass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,21 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.1)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     ffi (1.15.5)
+    gapic-common (0.14.0)
+      faraday (>= 1.9, < 3.a)
+      faraday-retry (>= 1.0, < 3.a)
+      google-protobuf (~> 3.14)
+      googleapis-common-protos (>= 1.3.12, < 2.a)
+      googleapis-common-protos-types (>= 1.3.1, < 2.a)
+      googleauth (~> 1.0)
+      grpc (~> 1.36)
     gems (1.2.0)
+    google-analytics-data-v1beta (0.6.0)
+      gapic-common (>= 0.12, < 2.a)
+      google-cloud-errors (~> 1.0)
     google-api-client (0.53.0)
       google-apis-core (~> 0.1)
       google-apis-generator (~> 0.1)
@@ -37,6 +50,14 @@ GEM
       google-apis-core (>= 0.9.1, < 2.a)
       google-apis-discovery_v1 (~> 0.5)
       thor (>= 0.20, < 2.a)
+    google-cloud-errors (1.3.0)
+    google-protobuf (3.21.9)
+    googleapis-common-protos (1.3.12)
+      google-protobuf (~> 3.14)
+      googleapis-common-protos-types (~> 1.2)
+      grpc (~> 1.27)
+    googleapis-common-protos-types (1.4.0)
+      google-protobuf (~> 3.14)
     googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
@@ -44,6 +65,9 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    grpc (1.50.0)
+      google-protobuf (~> 3.21)
+      googleapis-common-protos-types (~> 1.0)
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -101,6 +125,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   dotenv
+  google-analytics-data-v1beta
   google-api-client
   googleauth
   json

--- a/content.rb
+++ b/content.rb
@@ -9,17 +9,29 @@ class Content
   end
 
   def most_popular_govuk_pages
-    rows = response_hash[:rows]
-    formatted = []
-    rows.each do |row|
-      row_data = {
-        page_views: row[:metric_values][0][:value],
-        page_path: row[:dimension_values][0][:value],
-        page_title: row[:dimension_values][1][:value]
-      }
-      formatted << row_data
+    begin
+      rows = response_hash[:rows]
+    rescue StandardError => e
+      puts "#{e.message}"
+      [
+        {
+          page_views: "No data available",
+          page_path: "",
+          page_title: "No data available"
+        }.to_json
+      ]
+    else
+      formatted = []
+      rows.each do |row|
+        row_data = {
+          page_views: row.dig(:metric_values).first.dig(:value),
+          page_path: row.dig(:dimension_values).first.dig(:value),
+          page_title: row.dig(:dimension_values)[1].dig(:value)
+        }
+        formatted << row_data
+      end
+      formatted.to_json
     end
-    formatted.to_json  
   end
 
 private

--- a/realtime_traffic.rb
+++ b/realtime_traffic.rb
@@ -1,0 +1,37 @@
+require "google/analytics/data/v1beta"
+require 'json'
+
+class RealtimeTraffic
+  attr_reader :client
+  def initialize
+    @client = ::Google::Analytics::Data::V1beta::AnalyticsData::Client.new
+  end
+
+  def active_users
+    formatted_responses = {
+      active_users_30_minutes: response_hash[:rows][0][:metric_values][0][:value]
+    }
+    formatted_responses.to_json
+  end
+
+private
+
+  def request
+    { property: "properties/330577055", metrics: [set_metric] }
+  end
+
+  def set_metric
+    #https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#metrics
+    Google::Analytics::Data::V1beta::Metric.new(
+      name: "activeUsers"
+    )
+  end
+
+  def response
+    client.run_realtime_report(request)
+  end
+
+  def response_hash
+    response.to_h
+  end
+end

--- a/realtime_traffic.rb
+++ b/realtime_traffic.rb
@@ -8,10 +8,16 @@ class RealtimeTraffic
   end
 
   def active_users
-    formatted_responses = {
-      active_users_30_minutes: response_hash[:rows][0][:metric_values][0][:value]
-    }
-    formatted_responses.to_json
+    begin
+      formatted_responses = {
+        active_users_30_minutes: response_hash.dig(:rows).first.dig(:metric_values).first.dig(:value)
+      }
+    rescue StandardError => e
+      puts "#{e.message}"
+      {active_users_30_minutes: "No data available"}.to_json
+    else
+      formatted_responses.to_json
+    end
   end
 
 private

--- a/server.rb
+++ b/server.rb
@@ -8,6 +8,7 @@ require 'active_support'
 require 'active_support/core_ext/hash'
 require 'dotenv/load'
 require_relative 'content'
+require_relative 'realtime_traffic'
 
 use Rack::Cache
 set :public_folder, 'public'
@@ -60,6 +61,12 @@ get '/popular-content' do
 
   content = Content.new()
   content.most_popular_govuk_pages
+end
+
+get '/realtime-traffic' do
+  content_type :json
+  traffic = RealtimeTraffic.new
+  traffic.active_users
 end
 
 def get_token

--- a/server.rb
+++ b/server.rb
@@ -9,6 +9,7 @@ require 'active_support/core_ext/hash'
 require 'dotenv/load'
 require_relative 'content'
 require_relative 'realtime_traffic'
+require_relative 'traffic_report'
 
 use Rack::Cache
 set :public_folder, 'public'
@@ -67,6 +68,12 @@ get '/realtime-traffic' do
   content_type :json
   traffic = RealtimeTraffic.new
   traffic.active_users
+end
+
+get '/traffic-report' do
+  content_type :json
+  traffic = TrafficReport.new
+  traffic.visits_per_hour_past_day
 end
 
 def get_token

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -12,7 +12,7 @@ class TrafficReport
     formatted = []
     rows.each do |row|
       formatted << {
-        hour: row[:dimension_values][0][:value],
+        hour: format_hour_value(row[:dimension_values][0][:value]),
         visits: row[:metric_values][0][:value]
       }
     end
@@ -68,5 +68,9 @@ private
 
   def response_hash
     response.to_h
+  end
+
+  def format_hour_value(hour_data)
+    hour_data == "(other)" ? "total_visitors_24_hours" : hour_data
   end
 end

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -1,0 +1,72 @@
+require "google/analytics/data/v1beta"
+require 'json'
+
+class TrafficReport
+  attr_reader :client
+  def initialize
+    @client = ::Google::Analytics::Data::V1beta::AnalyticsData::Client.new
+  end
+
+  def visits_per_hour_past_day
+    rows = response_hash[:rows]
+    formatted = []
+    rows.each do |row|
+      formatted << {
+        hour: row[:dimension_values][0][:value],
+        visits: row[:metric_values][0][:value]
+      }
+    end
+    formatted.to_json
+  end
+
+private
+
+  def request
+    ::Google::Analytics::Data::V1beta::RunReportRequest.new({
+      property: "properties/330577055",
+      date_ranges: [
+       { start_date: 'yesterday', end_date: 'today'}
+      ],
+      dimensions: [set_dimension],
+      metrics: [set_metric],
+      order_bys: [set_order]
+    })
+  end
+
+  def set_dimension
+    #https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#dimensions
+    Google::Analytics::Data::V1beta::Dimension.new(
+      name: "hour"
+    )
+  end
+
+  def set_metric
+    #https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#metrics
+    Google::Analytics::Data::V1beta::Metric.new(
+      name: "activeUsers"
+    )
+  end
+
+  def set_order
+    Google::Analytics::Data::V1beta::OrderBy.new(
+      {
+        dimension: Google::Analytics::Data::V1beta::OrderBy::DimensionOrderBy.new(
+          {
+            dimension_name: 'hour',
+            order_type: Google::Analytics::Data::V1beta::OrderBy::DimensionOrderBy::OrderType::NUMERIC
+        
+          }
+        ),
+        desc: true 
+      }
+    )
+  end
+
+  def response
+    client.run_report request
+  end
+
+  def response_hash
+    response.to_h
+  end
+end

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -8,15 +8,24 @@ class TrafficReport
   end
 
   def visits_per_hour_past_day
-    rows = response_hash[:rows]
-    formatted = []
-    rows.each do |row|
-      formatted << {
-        hour: format_hour_value(row[:dimension_values][0][:value]),
-        visits: row[:metric_values][0][:value]
-      }
+    begin
+      rows = response_hash[:rows]
+    rescue StandardError => e
+      puts "#{e.message}"
+      {
+        hour: "No data available",
+        visits: "No data available"
+      }.to_json
+    else
+      formatted = []
+      rows.each do |row|
+        formatted << {
+          hour: format_hour_value(row.dig(:dimension_values).first.dig(:value)),
+          visits: row.dig(:metric_values).first.dig(:value)
+        }
+      end
+      formatted.to_json
     end
-    formatted.to_json
   end
 
 private


### PR DESCRIPTION
- Presents number of active users using the GA4 realtime API to /realtime-traffic.
- Presents number of users per hour for the past 24 hours (along with total users over past 24 hours) to /traffic-report.
- The data from the above 2 points ^ will be used for the number of active users count and graph.
- /popular-content has been updated to use the GA4 API (Google::Analytics::Data::V1beta::AnalyticsData::Client) as opposed to the UA API (AnalyticsreportingV4::AnalyticsReportingService). 
 
We are in the process of switching from UA to GA4, but GA4 page views has been implemented for most of GOV.UK. This and an issue with our Realtime UA data being unreliable, means that we are now using the GA4 API for most of this dashboard. The /search results still uses the UA Realtime API, however it uses oAuth credentials so they don't clash with the Google service credentials. The service credentials are now shared between content.rb, realtime_traffic.rb and traffic_report.rb. Updating /search to GA4 will be investigated as part of a separate task.

<img width="1675" alt="popular-content-ga4" src="https://user-images.githubusercontent.com/5963488/201669815-70669b8f-b299-4317-a1b6-8dd712316224.png">

<img width="684" alt="popular-content-error" src="https://user-images.githubusercontent.com/5963488/201669832-304303a2-0888-42e6-a329-49d43cdb86be.png">

<img width="1672" alt="hourly-traffic-report" src="https://user-images.githubusercontent.com/5963488/201669864-9695146d-7482-4751-8ef7-b6be0689356b.png">

<img width="380" alt="realtime-traffic" src="https://user-images.githubusercontent.com/5963488/201669884-76650733-5b2c-4ef2-b692-70c787ef67fe.png">

Paired with @GDSNewt 

