### PR TITLE
Remove '(other)' results from API response

### DIFF
--- a/content.rb
+++ b/content.rb
@@ -23,18 +23,29 @@ class Content
     else
       formatted = []
       rows.each do |row|
-        row_data = {
-          page_views: format_page_views_with_commas(row.dig(:metric_values).first.dig(:value)),
-          page_path: row.dig(:dimension_values).first.dig(:value),
-          page_title: row.dig(:dimension_values)[1].dig(:value)
-        }
-        formatted << row_data
+        page_title = row.dig(:dimension_values)[1].dig(:value)
+        unless other_result(page_title)
+          row_data = {
+            page_views: format_page_views_with_commas(row.dig(:metric_values).first.dig(:value)),
+            page_path: row.dig(:dimension_values).first.dig(:value),
+            page_title: page_title
+          }
+          formatted << row_data
+        end
       end
       formatted.to_json
     end
   end
 
 private
+
+  def other_result(page_title)
+    #Sometimes the API returns '(other)' results which skew the data:
+    #https://support.google.com/analytics/answer/9309767#zippy=%2Cin-this-article.
+    #It doesn't look like we can eliminate them using the API query itself.
+    #There are only max 10 results, so a Ruby check has been added to eliminate (other) results.
+    page_title == "(other)"
+  end
 
   def request
     ::Google::Analytics::Data::V1beta::RunReportRequest.new({


### PR DESCRIPTION
Sometimes the API returns '(other)' results which skew the data: https://support.google.com/analytics/answer/9309767#zippy=%2Cin-this-article. 

We are already using Analytics360 and predefined dimensions like the docs suggest. It doesn't look like we can eliminate them using the API query itself. There are only max 10 results, so a Ruby check has been added to eliminate (other) results.

| Before      | After|
| ----------- | ----------- |
| <img width="1709" alt="Screenshot 2022-11-16 at 17 27 24" src="https://user-images.githubusercontent.com/5963488/202251135-df850db4-6135-4a1f-adaa-b790768240bd.png">      | <img width="1724" alt="Screenshot 2022-11-16 at 17 26 53" src="https://user-images.githubusercontent.com/5963488/202251177-39cddbe6-734d-44ab-a2ec-611ee93e88d6.png">       |
