### PR TITLE
Fix incorrectly named value

### DIFF
--- a/public/javascripts/traffic-report.js
+++ b/public/javascripts/traffic-report.js
@@ -36,7 +36,7 @@
       const data = []
       const labels = []
       for( var i = 0; i < traffic_report.visits_per_hour.length; i++ ){
-        if( traffic_report.visits_per_hour[i].hour != "total_visitors_24_hours"){
+        if( traffic_report.visits_per_hour[i].hour != "(other)"){
           labels.push(traffic_report.visits_per_hour[i].hour)
           data.push(traffic_report.visits_per_hour[i].visits)
          }

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -20,7 +20,7 @@ class TrafficReport
       formatted = []
       rows.each do |row|
         formatted << {
-          hour: format_hour_value(row.dig(:dimension_values).first.dig(:value)),
+          hour: row.dig(:dimension_values).first.dig(:value),
           visits: row.dig(:metric_values).first.dig(:value)
         }
       end
@@ -77,9 +77,5 @@ private
 
   def response_hash
     response.to_h
-  end
-
-  def format_hour_value(hour_data)
-    hour_data == "(other)" ? "total_visitors_24_hours" : hour_data
   end
 end


### PR DESCRIPTION
Previously I formatted the '(other)' row that came back from the API as `total_number_of_users`. I incorrectly thought this was what the value represented. I've since learnt that:

`When the result of multiplying the cardinality of each dimension in a report exceeds the row limit, Analytics displays an "(other)" row.`

https://support.google.com/analytics/answer/9309767?hl=en#zippy=%2Cin-this-article

Therefore I am removing the method that incorrectly formatted the name of the 'other' hour value. For now it will just be called 'other'.

We are currently working on eliminating or reducing this 'other' value.

<img width="1672" alt="Screenshot 2022-11-23 at 14 47 38" src="https://user-images.githubusercontent.com/5963488/203576245-308acbfd-87b0-46e1-a1bb-475b3a6d7ce2.png">

<img width="1701" alt="Screenshot 2022-11-23 at 14 49 04" src="https://user-images.githubusercontent.com/5963488/203576459-99e9c012-360a-462d-85e5-12a08990f596.png">



