### PR TITLE
Graph last 24 hours relevant to current hour

### DIFF
--- a/public/javascripts/traffic-report.js
+++ b/public/javascripts/traffic-report.js
@@ -24,7 +24,7 @@
       const ctx = document.getElementById('traffic-count-graph').getContext('2d')
       traffic_report.$el = $(ctx);
       traffic_report.reload();
-      window.setInterval(traffic_report.reload, 60e3 * 60 * 24);
+      window.setInterval(traffic_report.reload, 6000);
     },
     reload: function(){
       var endpoint = traffic_report.endpoint();
@@ -106,7 +106,7 @@
         } else {
           num = orderedHours[i]
         }
-        formattedHours.push(num + ":00")
+        formattedHours.push(num)
       }
       return formattedHours
     }

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -20,7 +20,7 @@ class TrafficReport
       formatted = []
       rows.each do |row|
         formatted << {
-          hour: row.dig(:dimension_values).first.dig(:value),
+          hour: format_date_hour(row.dig(:dimension_values).first.dig(:value)),
           visits: row.dig(:metric_values).first.dig(:value)
         }
       end
@@ -47,7 +47,7 @@ private
   def set_dimension
     #https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#dimensions
     Google::Analytics::Data::V1beta::Dimension.new(
-      name: "hour"
+      name: "dateHour"
     )
   end
 
@@ -63,7 +63,7 @@ private
       {
         dimension: Google::Analytics::Data::V1beta::OrderBy::DimensionOrderBy.new(
           {
-            dimension_name: 'hour',
+            dimension_name: 'dateHour',
             order_type: Google::Analytics::Data::V1beta::OrderBy::DimensionOrderBy::OrderType::NUMERIC
         
           }
@@ -79,5 +79,10 @@ private
 
   def response_hash
     response.to_h
+  end
+
+  def format_date_hour(date_hour)
+     parsed_date_hour = DateTime.parse(date_hour)
+     parsed_date_hour.strftime('%H:%M')
   end
 end

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -54,7 +54,7 @@ private
   def set_metric
     #https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#metrics
     Google::Analytics::Data::V1beta::Metric.new(
-      name: "activeUsers"
+      name: "totalUsers"
     )
   end
 

--- a/traffic_report.rb
+++ b/traffic_report.rb
@@ -38,7 +38,9 @@ private
       ],
       dimensions: [set_dimension],
       metrics: [set_metric],
-      order_bys: [set_order]
+      order_bys: [set_order],
+      limit: 25,
+      offset: 0
     })
   end
 


### PR DESCRIPTION
[Trello](https://github.com/alphagov/govuk-display-screen/pull/77)
- Makes a few of the changes that we were advised to make to improve cardinality skewing the data.
- Changes graph to display 24 hours of data relative to current hour.

Previously we were using the `hour` dimension with the date range set to `yesterday` -> `today`. This was actually giving us data for 2 days summed into 1.

Using the `hour` value would be better if we wanted data from only today (so far) or the whole of only yesterday. Using dateHour allows us to display data for the last 24 hours relative to the current hour.

### Before

Yesterday -> Today with `hour` dimension (its taking data from midnight - midnight but adding them up for both days where it can.. I think): 
<img width="1050" alt="yesterday-today-hour" src="https://user-images.githubusercontent.com/5963488/203847078-f471b234-eadc-467d-b708-85afad770977.png">

### After

Yesterday -> Today with dateHour dimension (uses relative 24 hours which includes data from yesterday and today but doesn't sum them together):
<img width="1051" alt="Screenshot 2022-11-24 at 18 12 25" src="https://user-images.githubusercontent.com/5963488/203847170-b2020493-98d6-4597-a137-88628ac93ccc.png">

### Other examples:

Today -> Today with `dateHour` dimension (taken around 4pm)
<img width="1050" alt="today-today-date-hour" src="https://user-images.githubusercontent.com/5963488/203847286-e8f26345-369a-433a-8426-d7928da8164e.png">

Today -> Today with `hour` dimension (taken around 4pm)


<img width="1055" alt="today-today-hour" src="https://user-images.githubusercontent.com/5963488/203847431-c725186a-f2bf-489b-a56e-cd387eb2db54.png">

Yesterday -> Yesterday with `dateHour` dimension

<img width="1054" alt="yesterday-yesterday-date-hour" src="https://user-images.githubusercontent.com/5963488/203847482-9ca40c65-226d-4087-80bd-4d3422c309c1.png">

Yesterday -> Yesterday with `hour` dimension

<img width="1052" alt="yesterday-yesterday-hour" src="https://user-images.githubusercontent.com/5963488/203847501-d70cb9d6-14d3-406c-9db3-b9f72f7e2f57.png">









The AJAX request has been set to update once an hour. This should mean that the graph updates over the course of the day, which will be more interesting to look at.

Some formatting has been done on the labels to just show the hour values.

There is still a data issue with the numbers themselves due to cardinality. We are going to speak to Google about this.