### PR TITLE
Redesign dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <!--[if !IE 8]><!-->
     <link rel="stylesheet" href="/stylesheets/govuk-frontend-4.3.1.min.css">
+    <link rel="stylesheet" href="/stylesheets/govuk-custom-dashboard.css">
     <!--<![endif]-->
     <!--[if IE 8]>
         <link rel="stylesheet" href="/stylesheets/govuk-frontend-ie8-4.3.1.min.css">
@@ -17,8 +18,8 @@
   </head>
 
   <body class="govuk-template__body">
-    <header class="govuk-header" role="banner" style="border-bottom: 10px solid #0b0c0c" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container" style="border-bottom: 10px solid #0b0c0c; margin-left: 20px;">
+    <header class="govuk-header dashboard-banner" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container dashboard-banner-inner">
         <div class="govuk-header__logo">
           <a href="#" class="govuk-header__link govuk-header__link--homepage">
             <span class="govuk-header__logotype">
@@ -42,12 +43,12 @@
       </div>
     </header>
     
-    <main class="govuk-main-wrapper" style="padding: 20px; background-color: #263135;">
+    <main class="govuk-main-wrapper dashboard-background">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
           <div class="small-box traffic">
-            <h1 class="govuk-notification-banner__title" id="traffic-count" style="text-align: left; font-size: 72px;"></h1>
-            <h2 class="govuk-notification-banner__title govuk-!-margin-bottom-7" id="govuk-notification-banner-title" style="text-align: left;">
+            <h1 class="govuk-notification-banner__title dashboard-number-count" id="traffic-count"></h1>
+            <h2 class="govuk-notification-banner__title govuk-!-margin-bottom-7" id="govuk-notification-banner-title">
               Users on GOV.UK in the last 30 minutes
             </h2>    
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,11 @@
 <html lang="en" class="govuk-template ">
   <head>
     <title>Data Screen</title>
+    <style>
+      * {
+        color: #ffffff !important;
+      }
+    </style>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <!--[if !IE 8]><!-->
     <link rel="stylesheet" href="/stylesheets/govuk-frontend-4.3.1.min.css">
@@ -37,7 +42,7 @@
       </div>
     </header>
     
-    <main class="govuk-main-wrapper" style="padding: 20px">
+    <main class="govuk-main-wrapper" style="padding: 20px; background-color: #263135;">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
           <div class="small-box traffic">
@@ -60,7 +65,7 @@
           </div>
         </div>
       </div>
-      <div class="govuk-grid-row">
+      <div class="govuk-grid-row" >
         <div class="govuk-grid-column-one-third">
           <h2 class="govuk-heading-l govuk-!-margin-bottom-7">Live Searches</h2>
           <ul class="govuk-list" id="search"></ul>

--- a/public/index.html
+++ b/public/index.html
@@ -17,8 +17,8 @@
   </head>
 
   <body class="govuk-template__body">
-    <header class="govuk-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container" style="border-bottom: 10px solid #ffffff; margin-left: 20px;">
+    <header class="govuk-header" role="banner" style="border-bottom: 10px solid #0b0c0c" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container" style="border-bottom: 10px solid #0b0c0c; margin-left: 20px;">
         <div class="govuk-header__logo">
           <a href="#" class="govuk-header__link govuk-header__link--homepage">
             <span class="govuk-header__logotype">
@@ -46,22 +46,10 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
           <div class="small-box traffic">
-            <div id="traffic" class="count">
-              <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                  <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title" style="text-align: center;">
-                    Users on GOV.UK in the last 30 minutes
-                  </h2>
-                </div>
-                <div class="govuk-notification-banner__content">
-                  <p class="govuk-notification-banner__heading">
-                    <div class="box-inner">
-                      <h1 id="traffic-count" style="text-align: center;"></h1>
-                    </div>
-                  </p>
-                </div>
-              </div>
-            </div>
+            <h1 class="govuk-notification-banner__title" id="traffic-count" style="text-align: left; font-size: 72px;"></h1>
+            <h2 class="govuk-notification-banner__title govuk-!-margin-bottom-7" id="govuk-notification-banner-title" style="text-align: left;">
+              Users on GOV.UK in the last 30 minutes
+            </h2>    
           </div>
         </div>
       </div>

--- a/public/stylesheets/govuk-custom-dashboard.css
+++ b/public/stylesheets/govuk-custom-dashboard.css
@@ -1,0 +1,18 @@
+.dashboard-banner {
+    border-bottom: 10px solid #0b0c0c;
+}
+
+.dashboard-banner-inner {
+    border-bottom: 10px solid #0b0c0c; 
+    margin-left: 20px;
+}
+
+.dashboard-background {
+    padding: 20px; 
+    background-color: #263135;
+}
+
+.dashboard-number-count {
+    text-align: left; 
+    font-size: 72px;
+}


### PR DESCRIPTION
We asked a designer to take a look at our recent work to the dashboard and to suggest changes we could make. We changed the colour scheme and layout to make the dashboard more energy efficient and sleeker in appearance.

[Trello card](https://trello.com/c/1TZEfKz6/288-design-feedback-for-govuk-display-screen)

### **BEFORE

<img width="1725" alt="Screenshot 2022-12-02 at 11 39 42" src="https://user-images.githubusercontent.com/41922771/205695935-3b172818-89dc-42c1-b187-41e16ac5beb9.png">

### **AFTER**

![Screenshot 2022-12-05 at 16 43 30](https://user-images.githubusercontent.com/41922771/205695783-fabfacb4-4836-4e1c-a906-09686ec39258.png)



Co-authored-by: [Sonia Hussain](https://github.com/alphagov/govuk-display-screen/commits?author=CodeSonia)