### PR TITLE
Add rackup gem to fix start-up error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem 'sass'
 gem 'sinatra'
 gem "dotenv"
 gem "google-analytics-data-v1beta"
+gem "rackup"
 gem 'puma'
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
       rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -110,6 +113,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (0.13.0)
+    webrick (1.8.1)
 
 PLATFORMS
   arm64-darwin-21
@@ -122,6 +126,7 @@ DEPENDENCIES
   json
   puma
   rack-cache
+  rackup
   sass
   sinatra
 


### PR DESCRIPTION
This is to resolve the application erroring with:

```
Sinatra could not start, the "rackup" gem was not found!

Add it to your bundle with:

    bundle add rackup

or install it with:

    gem install rackup
```

This error began occurring once the application was upgraded to Sinatra 4.