### PR TITLE
Remove JS that causes error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,11 +80,9 @@
     <script src="javascripts/vendor/pretty.js"></script>
 
     <script src="javascripts/template.js"></script>
-    <script src="javascripts/sparkline.js"></script>
     <script src="javascripts/search.js"></script>
     <script src="javascripts/traffic.js"></script>
     <script src="javascripts/content.js"></script>
-    <script src="javascripts/inside-gov.js"></script>
 
     <script src="javascripts/manager.js"></script>
     <script>

--- a/public/javascripts/manager.js
+++ b/public/javascripts/manager.js
@@ -14,7 +14,6 @@
       matrix.traffic.init();
       matrix.search.init();
       matrix.content.init();
-      matrix.insideGov.init();
     },
   };
   root.matrix.manager = manager;


### PR DESCRIPTION
Trello: https://trello.com/c/j3FgSU9y/1092-govuk-display-screen-is-erroring-on-heroku

This removes a reference to load 2 JS files that no longer exist and return 404's and an init call on an object that does not exist.