### PR TITLE
Update google-protobuf for Ruby 3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,8 @@ GEM
     google-cloud-env (2.1.1)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.3.1)
-    google-protobuf (3.25.2-arm64-darwin)
-    google-protobuf (3.25.2-x86_64-linux)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos (1.4.0)
       google-protobuf (~> 3.14)
       googleapis-common-protos-types (~> 1.2)
@@ -56,10 +56,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    grpc (1.60.0-arm64-darwin)
-      google-protobuf (~> 3.25)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.60.0-x86_64-linux)
+    grpc (1.60.0)
       google-protobuf (~> 3.25)
       googleapis-common-protos-types (~> 1.0)
     i18n (1.14.1)
@@ -117,6 +114,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Trello: https://trello.com/c/j3FgSU9y/1092-govuk-display-screen-is-erroring-on-heroku

This gem is not compatible with Ruby 3.3 without being bumped as a version.

The additional platform of arm64-darwin-23 is caused because I'm running on macOS Sonoma, it's a bit annoying that this changes for macOS releases :-(.